### PR TITLE
Ajout de la mise à jour du prix unitaire TTC

### DIFF
--- a/class/actions_quickcustomerprice.class.php
+++ b/class/actions_quickcustomerprice.class.php
@@ -203,8 +203,11 @@ class Actionsquickcustomerprice
 			  						$('tr[id=row-'+lineid+'] td.liencolht').html(data.total_ht);
 			  						$('tr[id=row-'+lineid+'] td.linecoldiscount a').html(data.remise_percent+'%');
 			  						$('tr[id=row-'+lineid+'] td.linecolqty a').html(data.qty);
-			  						$('tr[id=row-'+lineid+'] td.linecoluht a').html(data.price);
-			  						
+			  						$('tr[id=row-'+lineid+'] td.linecoluht a').html(data.price);									
+									<?php if( (float)DOL_VERSION>3.8 ) { ?>
+			  						  $('tr[id=row-'+lineid+'] td.linecoluttc').html(data.uttc);
+									<?php } ?>
+									
 			  						$link.attr('value',data[col]);
 			  						
 			  					});


### PR DESCRIPTION
Petit fix qui fonctionne à partir de la version 3.9 pour mettre à jour le prix unitaire TTC après avoir changé le prix H.T

Lié à un changement du fichier /scripts/interface.php sur la fonction _updateLine qui permet de renvoyer la data "uttc" (Prix Unitaire TTC)