### PR TITLE
Ajout Actualisation du Prix unitaire TTC

### DIFF
--- a/class/actions_quickcustomerprice.class.php
+++ b/class/actions_quickcustomerprice.class.php
@@ -204,7 +204,9 @@ class Actionsquickcustomerprice
 			  						$('tr[id=row-'+lineid+'] td.linecoldiscount a').html(data.remise_percent+'%');
 			  						$('tr[id=row-'+lineid+'] td.linecolqty a').html(data.qty);
 			  						$('tr[id=row-'+lineid+'] td.linecoluht a').html(data.price);
-			  						
+									<?php if( (float)DOL_VERSION>3.8 ) { ?>
+									  $('tr[id=row-'+lineid+'] td.linecoluttc').html(data.uttc);
+									<?php } ?>				  						
 			  						$link.attr('value',data[col]);
 			  						
 			  					});


### PR DESCRIPTION
Petit fix pour mettre à jour le Prix unitaire T.T.C, suite à modification du Prix unitaire H.T.

En complément de la modification sur le fichier /scripts/intereface.pfp

Note : Pour les versions antérieur à Dolibarr 3.9, il faut rajouter la class sur la colonne de Prix Unitaire H.T