### PR TITLE
FIX: jQuery error if user has no quickcustomerprice rights

### DIFF
--- a/class/actions_quickcustomerprice.class.php
+++ b/class/actions_quickcustomerprice.class.php
@@ -155,8 +155,9 @@ class Actionsquickcustomerprice
                             $strToFind[] = 'td.linecolqty';
                         }
                         if(! empty($user->rights->quickcustomerprice->edit_discount)) $strToFind[] = 'td.linecoldiscount';
+                        $strToFind[] = 'td.linecolcycleref';
                     ?>
-			  		$('table#tablelines tr[id]').find('<?php echo implode(',', $strToFind); ?>'+',td.linecolcycleref').each(function(i,item) {
+			  		$('table#tablelines tr[id]').find('<?php echo implode(',', $strToFind); ?>').each(function(i,item) {
 			  			value = $(item).html();
 			  			if(value=='&nbsp;')value='';
 			  			
@@ -170,9 +171,9 @@ class Actionsquickcustomerprice
 			  			else if($(item).hasClass('linecolqty')) {
 			  				col='qty';
 			  			}
-                                                else if($(item).hasClass('linecolcycleref')) {
-                                                        col='situation_cycle_ref';
-                                                }
+                        else if($(item).hasClass('linecolcycleref')) {
+                                col='situation_cycle_ref';
+                        }
 			  			else {
 			  				col = 'price';
 			  			}


### PR DESCRIPTION
FIX: jQuery error if user has no quickcustomerprice rights (none of "edit_unit_price", "edit_quantity", "edit_discount")
+ indentation fix