### PR TITLE
Fix fichehalfright deseapear on update price line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,5 +4,6 @@
 
 
 ## 3.1
+- FIX: minor v15 compatibility issues - *2022-01-31* - 3.1.2
 - FIX: minor v14 compatibility issues - *2021-10-12* - 3.1.1
 - no changelog up to this point - *2021-10-12* - 3.1.0

--- a/class/actions_quickcustomerprice.class.php
+++ b/class/actions_quickcustomerprice.class.php
@@ -64,7 +64,7 @@ class Actionsquickcustomerprice
         global $user, $conf;
 
 		$error = 0;
-//var_dump($parameters['currentcontext']);
+
 		if (
 			$parameters['currentcontext'] == 'propalcard'
 			|| $parameters['currentcontext'] == 'ordercard'
@@ -264,7 +264,12 @@ class Actionsquickcustomerprice
 
                                         //On remplace en direct les montants de la fiche
                                         var url = "<?php echo $_SERVER['PHP_SELF'] ?>?id=" + objectid;
-                                        $(".tabBar .fichehalfright").load(url + " .tabBar .fichehalfright .ficheaddleft");
+
+										<?php if (version_compare(DOL_VERSION, '14.0', '>')) { ?>
+                                        	$(".tabBar .fichecenter").load(url + " .tabBar .fichecenter .fichehalfleft, .tabBar .fichecenter .fichehalfright");
+										<?PHP }else { ?>
+											$(".tabBar .fichehalfright").load(url + " .tabBar .fichehalfright .ficheaddleft");
+										<?PHP } ?>
 
                                         // we call the callback functions potentially added by hooks
                                         priceCallbacks.forEach((callback) => {

--- a/core/modules/modquickcustomerprice.class.php
+++ b/core/modules/modquickcustomerprice.class.php
@@ -60,7 +60,7 @@ class modquickcustomerprice extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module quickcustomerprice";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '3.1.1';
+		$this->version = '3.1.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
# FIX : 
la div fichehalfright disparaissait quand on mettait à jour un prix sur une ligne de propal 
test effectué également sur facture
résolution  : modification de l'appel ajax.