### PR TITLE
FIX DA025943 - Prendre en compte options d'affichage des colonnes marge / marque

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 ## Release 3.7
 
+- FIX : Prendre en compte options d'affichage des colonnes marge / marque - *09/01/2025* - 3.7.1
 - FIX : Compat v20 - *22/07/2024* - 3.7.0
   Changed Dolibarr compatibility range to 16 min - 20 max
   Changed PHP compatibility range to 7.1 min

--- a/class/actions_quickcustomerprice.class.php
+++ b/class/actions_quickcustomerprice.class.php
@@ -273,8 +273,16 @@ class Actionsquickcustomerprice extends quickcustomerprice\RetroCompatCommonHook
 										$('tr[id=row-'+lineid+'] td.linecoluht_currency a').attr('value',data.pu_ht_devise);
 										$('tr[id=row-'+lineid+'] td.linecolqty a').html(data.qty);
 										$('tr[id=row-'+lineid+'] td.linecolmargin1 a').html(data.pa_ht);
-										$('tr[id=row-'+lineid+'] td.linecolmargin2:first').html(data.marge_tx);
-										$('tr[id=row-'+lineid+'] td.linecolmargin2:eq(1)').html(data.marque_tx);
+										// DA025943: solution sale en attendant une refonte
+										const marginOpts = <?= json_encode([
+											getDolGlobalInt('DISPLAY_MARGIN_RATES') ? 'marge_tx' : 0,
+											getDolGlobalInt('DISPLAY_MARK_RATES') ? 'marque_tx' : 0])
+											?>.filter(opt => opt);
+										for (let index = 0; index < marginOpts.length; index++) {
+											const marginOpt = marginOpts[index];
+											$(`tr[id=row-${lineid}] td.linecolmargin2:eq(${index})`).html(pricejs(parseFloat(data[marginOpt].replace(',', '.'))) + '%');
+										}
+
 										$('tr[id=row-'+lineid+'] td.linecoluht a').html(data.price);
 										$('tr[id=row-'+lineid+'] td.linecoluht a').attr('value',data.price);
 										$('tr[id=row-'+lineid+'] td.linecolcycleref a').html(data.situation_cycle_ref+'%');

--- a/core/modules/modquickcustomerprice.class.php
+++ b/core/modules/modquickcustomerprice.class.php
@@ -61,7 +61,7 @@ class modquickcustomerprice extends DolibarrModules
 		$this->description = "Modify a value of your product or service with one click";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '3.7.0';
+		$this->version = '3.7.1';
 
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';


### PR DESCRIPTION
Le module cœur Marges permet de choisir d'afficher les colonnes Marge et Marque, ou l'une des deux seulement, ou aucune.

- Quickcustomerprice n'en tient actuellement pas compte et fait comme si les deux étaient toujours affichées.
- En plus de ça, comme le DOM des fiches n'est pas ultra sémantique, il n'y a pas de classe permettant de distinguer les  `<td>` de la colonne Marge et de la colonne Marque (pas de `<td class="marginrate">` vs `<td class="markrate">` ou autre du style : les deux colonnes ont exactement les mêmes classes). Du coup, quickcustomerprice se base sur le fait que, lorsqu'il y a les deux, Marque est après Marge.

Par manque de temps, je n'ai pas encore ouvert de PR cœur pour améliorer la sémantique du DOM.
- [edit] apparemment, l'amélioration a été faite pour Dolibarr 21, du coup peu de chances que Laurent accepte de rétroporter ça dans les versions antérieures. Tant pis.

La solution de cette PR est un peu sale : elle consiste juste à lire les options d'affichage, à en faire un tableau js:
```js
[] // = aucune colonne affichée
['marge_tx'] // = seulement taux de marge
['marque_tx'] // = seulement taux de marque
['marge_tx', 'marque_tx'] // = taux de marge et taux de marque
```
À partir de ce tableau, on sait combien de colonnes sont affichées et quelle donnée on doit mettre dans chacune.


Si j'ai le temps, je ferai un ticket pour expliquer la refacto à faire sur ce module… il y en a un peu. :cry: 
